### PR TITLE
Nuevo procedimiento de alta de socies

### DIFF
--- a/content/pages/hazte-socio.md
+++ b/content/pages/hazte-socio.md
@@ -5,15 +5,61 @@ Este documento detalla el procedimiento que ha establecido Python España para q
 
 ## Quiero asociarme
 
-Realizar una transferencia de 30€ a la cuenta de la asociación indicando en el asunto el DNI/NIE y destinatario "Asociación Python España".
+**1.1. Quiero domiciliar el pago**
 
-Mandar un correo a la dirección: alta@es.python.org, adjuntando copia/foto del dni/nie, un teléfono de contacto y la copia/foto del comprobante de pago e indicando en el asunto "Alta nuevo socio".
+Realiza la transferencia correspondiente(*) a la cuenta de la asociación indicando en el asunto el DNI/NIE y destinatario "Asociación Python España".
+
+Mándanos un correo a la dirección alta@es.python.org, con el asunto "Alta nuevo socio", adjuntando:
+- copia/foto del dni/nie
+- un teléfono de contacto
+- la copia/foto del comprobante de pago
+- tu IBAN para poder domiciliarte el pago (se hará en febrero más o menos)
+
+**1.2. No quiero domiciliar el pago**
+
+Realiza la transferencia correspondiente(*) a la cuenta de la asociación indicando en el asunto el DNI/NIE y destinatario "Asociación Python España".
+Mándanos un correo a la dirección alta@es.python.org, con el asunto "Alta nuevo socio", adjuntando:
+- copia/foto del dni/nie
+- un teléfono de contacto
+- la copia/foto del comprobante de pago
+
+El próximo febrero te tocará pagar la cuota completa del año (¡te lo recordaremos!)
+
 
 ## Quiero renovar la cuota
 
-Realizar una transferencia de 30€ a la cuenta de la asociación indicando en el asunto el número de socio o DNI/NIE y destinatario "Asociación Python España".
+**2.1. Tengo la cuota domiciliada**
 
-Mandar un correo a la dirección: alta@es.python.org, adjuntando copia/foto del comprobante de pago e indicando en el asunto "Renovación cuota".
+¡Perfecto! Nos encargamos desde la Asociación :D
+
+**2.2. No tengo la cuota domiciliada pero me encantaría domiciliarla**
+
+En este caso, hace falta que realices la transferencia correspondiente(*) a la cuenta de la asociación indicando en el asunto el número de socio o DNI/NIE y destinatario "Asociación Python España".
+Después mándanos un correo a la dirección alta@es.python.org, adjuntando copia/foto del comprobante de pago e indicando en el asunto "Renovación cuota". Incluye en el correo tu número IBAN y te añadiremos al proceso automatizado (te llegará el recibo el próximo febrero).
+
+**2.3. No tengo la cuota domiciliada y quiero seguir así**
+
+Entonces hace falta realizar una transferencia de 30€ a la cuenta de la asociación indicando en el asunto el número de socio o DNI/NIE y destinatario "Asociación Python España".
+Mándanos un correo a la dirección alta@es.python.org, adjuntando copia/foto del comprobante de pago e indicando en el asunto "Renovación cuota".
+
+Antes de renovarla, te invitamos a que domicilies el pago o acompases tu renovación manual a febrero, nos facilitarías mucho la gestión a la Asociación. Para acompasar tu cuota con el resto de la Asociación, mira el siguiente apartado.
+
+## Quiero acompasar mi cuota con el resto de la Asociación
+
+**3.1. Y de paso domiciliar el pago**
+
+¡Fantástico! En este caso, sigue las indicaciones del punto 2.2.
+
+**3.2. Y seguir con las renovaciones manuales**
+
+¡Muchas gracias también! En este caso, cuando te toque renovar, realiza la transferencia correspondiente(*) de ese año natural (30€ en la primera mitad del año, 15€ en la segunda mitad del año). Después envíanos un correo adjuntando el comprobante de pago con el asunto "Renovación cuota", indicando que tu nueva fecha de renovación es la de la Asociación. El próximo febrero esperaremos una transferencia por tu parte (y te enviaremos un correo recordatorio por si se te pasa).
+
+
+**(*) Transferencia correspondiente**: Siempre que se pida una transferencia, la cantidad correspondiente será conforme a la siguiente norma:
+
+- en la primera mitad del año (enero - junio inclusive): 30€
+- en la segunda mitad del año (julio - diciembre inclusive): 15€
+
 
 ## Datos adicionales
 
@@ -27,12 +73,12 @@ ES18 1491 0001 2230 0008 5378
 ## Notas generales
 
 * El correo electrónico desde el que se mande la documentación requerida quedará asociado al nuevo socio a menos que se indique otro correo electrónico de contacto.
-*
+
 * El correo electrónico puede servir como parte de la verificación de identidad de los usuarios para acceso a una plataforma, donde por ejemplo, pueda verificar que su solicitud ha sido tramitada.
-*
+
 * El pago de la cuota es anual. Si pasados tres meses, no se ha producido el pago de la cuota correspondiente, se dará de baja al socio de forma automática.
-*
+
 * Si necesitas un certificado de pago de la cuota, por favor háznoslo saber, tanto para un alta nueva, como para una renovación, de forma que podamos enviártelo a tu correo electrónico.
-*
+
 * En cumplimiento de lo dispuesto en la Ley Orgánica 15/1999 de Protección de Datos de Carácter Personal, Python España, le informa que los datos personales que nos sean proporcionados van a ser incorporados para su tratamiento en ficheros automatizados. La recogida y tratamiento de dichos datos tienen como finalidad gestión de socios, comunicaciones electrónicas y/o la confección de estadísticas. Python España se compromete al cumplimiento de su obligación de secreto con respecto a los datos de carácter personal suministrados y al deber de tratarlos con confidencialidad y reserva, conforme a la legislación vigente. A estos efectos adoptará las medidas necesarias para evitar su alteración, pérdida, tratamiento o acceso no autorizado. Así mismo se le informa que, si lo desea puede ejercitar los derechos previstos en el Art. 5 de la Ley a través del correo electrónico socios@es.python.org, seleccionando como asunto LOPD e indicando su nombre completo, su DNI y el tipo de derecho que desea ejercitar, Acceso, Rectificación, Cancelación u Oposición.
 


### PR DESCRIPTION
Equipo redactor @delapuente @Nekmo @italofarve @rebost Aquí el PR que os comenté. Si podéis echar un vistazo, sería genial (¿se entiende bien el proceso? ¿se entiende bien que animamos a socios y socias a acompasarse con la fecha de la Asociación?); pero por favor, no lo mergeéis hasta que @Juanlu001 no de el visto bueno a la redacción y sobre todo al contenido.

@Juanlu001 confirma que esto encaja con lo que hemos hablado en JD, por favor.

¡Gracias a todos!