### PR TITLE
Moving Travis key generation to after_success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,17 @@ addons:
     packages:
       - rsync
       - openssh-client
-before_install:
-- openssl aes-256-cbc -K $encrypted_a9942967d0d9_key -iv $encrypted_a9942967d0d9_iv -in travis_access.enc -out travis_access -d
 
 install:
   - pip install -r requirements.txt
+
+script: pelican content
+
+after_success:
+  - openssl aes-256-cbc -K $encrypted_a9942967d0d9_key -iv $encrypted_a9942967d0d9_iv -in travis_access.enc -out travis_access -d
   - eval $(ssh-agent -s)
   - chmod 600 travis_access && ssh-add travis_access
   - mkdir -p ~/.ssh
   - echo -e "Host *\n\tStrictHostKeyChecking no\n\n" > ~/.ssh/config
-script: pelican content
-
-after_success:
   - rsync -avz --delete output/ $DEPLOYMENT_URL
 


### PR DESCRIPTION
This way we can enable CI for the PR of forks and get the green tick for them
despite the success of the deployment stage.