### PR TITLE
Deploy only if secure environment variables are available.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
 script: pelican content
 
 after_success:
-  - 'if [ ${TRAVIS_SECURE_ENV_VARS} ]; then
+  - 'if [ ${TRAVIS_SECURE_ENV_VARS} = "true" ]; then
        openssl aes-256-cbc -K $encrypted_a9942967d0d9_key -iv $encrypted_a9942967d0d9_iv -in travis_access.enc -out travis_access -d || travis_terminate 1;
        eval $(ssh-agent -s) || travis_terminate 1;
        chmod 600 travis_access && ssh-add travis_access || travis_terminate 1;

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,11 @@ install:
 script: pelican content
 
 after_success:
-  - openssl aes-256-cbc -K $encrypted_a9942967d0d9_key -iv $encrypted_a9942967d0d9_iv -in travis_access.enc -out travis_access -d
-  - eval $(ssh-agent -s)
-  - chmod 600 travis_access && ssh-add travis_access
-  - mkdir -p ~/.ssh
-  - echo -e "Host *\n\tStrictHostKeyChecking no\n\n" > ~/.ssh/config
-  - rsync -avz --delete output/ $DEPLOYMENT_URL
-
+  - 'if [ ${TRAVIS_SECURE_ENV_VARS} ]; then
+       openssl aes-256-cbc -K $encrypted_a9942967d0d9_key -iv $encrypted_a9942967d0d9_iv -in travis_access.enc -out travis_access -d || travis_terminate 1;
+       eval $(ssh-agent -s) || travis_terminate 1;
+       chmod 600 travis_access && ssh-add travis_access || travis_terminate 1;
+       mkdir -p ~/.ssh || travis_terminate 1;
+       echo -e "Host *\n\tStrictHostKeyChecking no\n\n" > ~/.ssh/config || travis_terminate 1;
+       rsync -avz --delete output/ $DEPLOYMENT_URL || travis_terminate 1;
+    fi'


### PR DESCRIPTION
Added a conditional test in the `after_success` script to test if there are
secure environment variables. Adding a `if` bash statement will make the script
to exit with 0 even if some internal command fails. Adding `travis_terminate 1`
terminates the build if an internal command fails.

Inspired by http://steven.casagrande.io/articles/travis-ci-and-if-statements/