### PR TITLE
Detección de URLs en el texto

### DIFF
--- a/content/2017-02-17-arranque-grupo-python-canarias.md
+++ b/content/2017-02-17-arranque-grupo-python-canarias.md
@@ -2,11 +2,11 @@ Title: Arranque oficial de la agrupación de Python en Canarias
 Date: 2017-02-17
 Summary: Desde hace varios años amantes y profesionales de Python en Canarias hemos celebrado con cierta asiduidad pequeños eventos llamados pyBirras(tm)...
 
-Desde hace varios años amantes y profesionales de Python en Canarias hemos celebrado con cierta asiduidad pequeños eventos llamados pyBirras(tm), donde de forma distentida y acompañados de cervezas (obviamente) y otras bebidas hemos podido compartir experiencias y conocimientos. Pero no ha sido sino hasta ahora que hemos decidido en constituirnos como agrupación local de <a href="http://pythoncanarias.es/" target="_new">Python en Canarias</a>.
+Desde hace varios años amantes y profesionales de Python en Canarias hemos celebrado con cierta asiduidad pequeños eventos llamados pyBirras(tm), donde de forma distentida y acompañados de cervezas (obviamente) y otras bebidas hemos podido compartir experiencias y conocimientos. Pero no ha sido sino hasta ahora que hemos decidido en constituirnos como agrupación local de [Python en Canarias](http://pythoncanarias.es/).
 
-Y para dar el pistoletazo de salida de la forma más potente posible nos hemos lanzado a organizar un <a href="http://pythoncanarias.es/pyday/" target="_new">pyDay en Tenerife</a> el sábado día 11 de marzo de 2017 en el edificio CajaCanarias, campus de Anchieta de la Universidad de La Laguna.
+Y para dar el pistoletazo de salida de la forma más potente posible nos hemos lanzado a organizar un [pyDay en Tenerife](http://pythoncanarias.es/pyday/) el sábado día 11 de marzo de 2017 en el edificio CajaCanarias, campus de Anchieta de la Universidad de La Laguna.
 
-En este evento <a href="http://pythoncanarias.es/pyday/inscripcion/" target="_new">gratuito</a> esperamos poder difundir las bondades de nuestro amado Python, tendremos dos tracks, de iniciación y avanzado con charlas de lo más variadas, pero sobre todo lo que queremos es que te unas a nosotros, queremos que pythoner@s de todas las islas juntemos esfuerzos para crear una comunidad fuerte y vibrante.
+En este evento [gratuito](http://pythoncanarias.es/pyday/inscripcion/) esperamos poder difundir las bondades de nuestro amado Python, tendremos dos tracks, de iniciación y avanzado con charlas de lo más variadas, pero sobre todo lo que queremos es que te unas a nosotros, queremos que pythoner@s de todas las islas juntemos esfuerzos para crear una comunidad fuerte y vibrante.
 
-Puedes comenzar a contactar con nosotros desde ya por <a href="mailto:info@pythoncanarias.es">email</a>, <a href="https://twitter.com/pythoncanarias" target="_new">twitter</a> o mediante el hastag #pyDayTF
+Puedes comenzar a contactar con nosotros desde ya por [email](mailto:info@pythoncanarias.es), [twitter](https://twitter.com/pythoncanarias) o mediante el hastag #pyDayTF
 

--- a/content/2017-04-02-pyday-tenerife-2017.md
+++ b/content/2017-04-02-pyday-tenerife-2017.md
@@ -5,7 +5,7 @@ Category: PyDay
 
 El pasado día 11 de Marzo, se celebró el **primer PyDay en Tenerife**.
 
-Congregó a más de 100 personas que tuvieron oportunidad de poder aprender sobre el lenguaje de programación Python. Las Charlas estuvieron divididas en dos tracks: uno de iniciación a la programación y otro más avanzado, con temas como robótica, micropython o visión artificial. El evento duró desde las 10 de la mañana hasta las 8 de la tarde. Se sortearon entre los asistentes un kit de Raspberry Py, cortesía del <a href="https://www.coitic.es/" target="_new">Colegio de Ingenieros de Informática de Canarias, COITIC</a>, y 10 placas con micropython, cortesía del <a href="http://kreitek.org/" target="_new">Hackers/Makers/Space Kreitek</a>.
+Congregó a más de 100 personas que tuvieron oportunidad de poder aprender sobre el lenguaje de programación Python. Las Charlas estuvieron divididas en dos tracks: uno de iniciación a la programación y otro más avanzado, con temas como robótica, micropython o visión artificial. El evento duró desde las 10 de la mañana hasta las 8 de la tarde. Se sortearon entre los asistentes un kit de Raspberry Py, cortesía del [Colegio de Ingenieros de Informática de Canarias, COITIC](https://coitic.es/), y 10 placas con micropython, cortesía del [Hackers/Makers/Space Kreitek](http://kreitek.org/).
 
-Puedes obtener más información, incluyendo las presentaciones de las ponencias y, en un futuro próximo, el vídeo de las mismas en la <a href="http://pythoncanarias.es/2017-03-27-resumen-pyday/" target="_new">página web de Python Canarias</a>.
+Puedes obtener más información, incluyendo las presentaciones de las ponencias y, en un futuro próximo, el vídeo de las mismas en la [página web de Python Canarias](http://pythoncanarias.es/2017-03-27-resumen-pyday/).
 

--- a/content/2017-05-12-pyday-galicia-2017.md
+++ b/content/2017-05-12-pyday-galicia-2017.md
@@ -5,19 +5,19 @@ Category: PyDay
 
 ¿Un día para disfrutar con Python en Galicia? ¡PyDay Galicia 2017!
 
-El próximo 10 de junio tendrá lugar una nueva edición de PyDay Galicia, un evento a nivel gallego organizado por Python Vigo con el apoyo de Python España. El año pasado lo celebramos a menor escala con muy buena <a href="https://www.facebook.com/media/set/?set=a.537721123085426.1073741834.438095649714641&type=1&l=2488aa0c57" target="_new">acogida</a>.
+El próximo 10 de junio tendrá lugar una nueva edición de PyDay Galicia, un evento a nivel gallego organizado por Python Vigo con el apoyo de Python España. El año pasado lo celebramos a menor escala con muy buena [acogida](https://www.facebook.com/media/set/?set=a.537721123085426.1073741834.438095649714641&type=1&l=2488aa0c57).
 
 Al igual que el año pasado, el evento será totalmente gratuito con el objetivo de que nadie se quede fuera y conseguir divulgar el conocimiento de Python lo más posible.
 
 El evento se celebrará en el auditorio del Museo Marco en pleno centro de Vigo, durará todo el día y constará de dos ‘tracks’ con charlas. Un track profesional donde habrá charlas de ponentes de primer nivel local y nacional y otro de iniciación donde cualquier pueda asistir y salir del evento con nociones básicas del lenguaje. En este segundo track contaremos con un taller para iniciarse en el uso de Python en Raspberry Pi.
 
-El evento cuenta con el patrocinio de varias empresas locales como <a href="https://www.gradiant.org/" target="_new">Gradiant</a>, <a href="https://initios.com/" target="_new">Initios</a> o <a href="https://www.empathybroker.com/" target="_new">EmpathyBroker</a> entre otros, además de la colaboración de diversos grupos locales de tecnología.
+El evento cuenta con el patrocinio de varias empresas locales como [Gradiant](https://www.gradiant.org/), [Initios](https://initios.com/) o [EmpathyBroker](https://www.empathybroker.com/) entre otros, además de la colaboración de diversos grupos locales de tecnología.
 
 Habrá tiempo para charlar, espacio para ofertas de trabajo, información de grupos de tecnología locales y sobretodo mucha gente con ganas de aprender y de enseñar.
 
 Os invitamos a todas y a todos a asistir para crear un ambiente participativo y diverso.
 
-<a href="https://pyday2017.python-vigo.es/" target="_new">https://pyday2017.python-vigo.es</a>
+https://pyday2017.python-vigo.es
 
 No te lo pierdas!!
 

--- a/content/2017-06-05-llamada-a-sedes-2018.md
+++ b/content/2017-06-05-llamada-a-sedes-2018.md
@@ -36,9 +36,9 @@ Los grupos que estén interesados en organizar la PyConES 2018 deberán enviar u
 
 Hay memorias de las ediciones de 2013 y 2015 (inacabada) para quien quiera llevarse algunas ideas.
 
-* [Memoria PyConES 2013](http://memoria-pycones-2013.readthedocs.io/)
+* [Memoria PyConES 2013](https://memoria-pycones-2013.readthedocs.io/)
 
-* [Memoria PyConES 2015]()
+* [Memoria PyConES 2015](https://memoria-pycones-2015.readthedocs.io/)
 
 Aquí os dejamos también la propuesta de Cáceres como referencia:
 

--- a/content/2017-06-05-llamada-a-sedes-2018.md
+++ b/content/2017-06-05-llamada-a-sedes-2018.md
@@ -36,11 +36,13 @@ Los grupos que estén interesados en organizar la PyConES 2018 deberán enviar u
 
 Hay memorias de las ediciones de 2013 y 2015 (inacabada) para quien quiera llevarse algunas ideas.
 
-* <a href="http://memoria-pycones-2013.readthedocs.io/" target="_new">Memoria PyConES 2013</a>
+* [Memoria PyConES 2013](http://memoria-pycones-2013.readthedocs.io/)
 
-* <a href="" target="_new">Memoria PyConES 2015</a>
+* [Memoria PyConES 2015]()
 
-Aquí os dejamos también la propuesta de Cáceres como referencia: <a href="https://drive.google.com/open?id=0B8R20_X-phP_NGFZNXF5UEE5NDQ" target="_new">https://drive.google.com/open?id=0B8R20_X-phP_NGFZNXF5UEE5NDQ</a>
+Aquí os dejamos también la propuesta de Cáceres como referencia:
+
+https://drive.google.com/open?id=0B8R20_X-phP_NGFZNXF5UEE5NDQ
 
 Además, desde la Junta estaremos encantados de resolveros las dudas iniciales que tengáis, presupuestos y datos de todo tipo con quienes lo solicitéis. Contactad con nosotros y contadnos un poco vuestra visión si no tenéis claro cómo enfocarla. Podemos tener una teleconferencia y compartir ideas.
 

--- a/content/2017-09-03-domiciliacion-cuotas.md
+++ b/content/2017-09-03-domiciliacion-cuotas.md
@@ -10,6 +10,6 @@ Hasta hace poco la asociación estaba atada a un banco con condiciones draconian
 
 Desde hace unos meses, conseguimos abrir una cuenta en Tríodos. El papeleo parecía no tener fin, pero nos ofrecían condiciones muy atractivas, especialmente para poder ofrecer nuevos servicios a los socios. Además de la domiciliación, hemos propuesto una forma de hacer que todas las cuotas se paguen en febrero, tanto las domiciliadas como las renovaciones manuales: esto facilitará el trabajo que hacemos desde tesorería y secretaría. Si renuevas tu cuota manualmente, considera pasar a pagarla en febrero por favor.
 
-En <a href="https://es.python.org/pages/hazte-socio.html" target="_blank">la página "Hazte socio"</a> está explicado el procedimiento en detalle. Si no queda claro o tenéis sugerencias, podéis contactar a través de la lista de correo de Python España o enviando un email a <a href="mailto:contacto2017@es.python.org">contacto2017@es.python.org</a>.
+En [la página "Hazte socio"](https://es.python.org/pages/hazte-socio.html) está explicado el procedimiento en detalle. Si no queda claro o tenéis sugerencias, podéis contactar a través de la lista de correo de Python España o enviando un email a [contacto2017@es.python.org](mailto:contacto2017@es.python.org).
 
 El equipo de Junta directiva ponemos mucha ilusión y esfuerzo por ir mejorando poco a poco la Asociación. Si tenéis ideas, hacelas llegar por los canales habituales, para que sepamos qué os gustaría como socios y socias tener en la Asociación.

--- a/content/2018-03-12-elecciones-2018.md
+++ b/content/2018-03-12-elecciones-2018.md
@@ -38,8 +38,7 @@ Más información en [el documento de pressentación de la candidatura](https://
 Socios/as al corriente de pago de las cuotas de la asociación. 
 Si no estáis al corriente de pago os recuerdo como va:
 
-1. Se hace el ingreso del importe pendiente a la cuenta de la asociación 
-[https://es.python.org/pages/hazte-socio.html](https://es.python.org/pages/hazte-socio.html) junto con la cuota
+1. Se hace el ingreso del importe pendiente a la [cuenta de la asociación](/pages/hazte-socio.html) junto con la cuota
 de este año o la domiciliación para que se pase la cuota en febrero.
 
 Aprovechad la ocasión para domiciliar los futuros pagos para simplificar la gestión de la asociación.
@@ -47,7 +46,7 @@ Aprovechad la ocasión para domiciliar los futuros pagos para simplificar la ges
 Delegación de voto
 ------------------
 
-Siguiendo las instrucciones que indican los estatutos (artículo 5 en http://documentos-asociacion.es.python.org/reglamento%20de%20r%C3%A9gimen%20interno.html#capitulo-i-asamblea-general) 
+Siguiendo las instrucciones que indican los estatutos ([artículo 5 en el reglamento de régimen interno](http://documentos-asociacion.es.python.org/reglamento%20de%20r%C3%A9gimen%20interno.html#capitulo-i-asamblea-general))
 podéis delegar el voto escribiendo un correo al secretario (antoni.aloy@gmail.com) o a la lista privada de la junta (junta@lists.es.python.org) 
 con copia a vuestro representante del voto indicando los siguientes datos del representado y el representante:
 
@@ -67,6 +66,6 @@ de la asociación.
 
 
 
- -- 
+ --
 Antoni Aloy López
 Secretario Saliente PythonES

--- a/content/pages/asociacion.md
+++ b/content/pages/asociacion.md
@@ -2,7 +2,7 @@ Title: Asociación
 
 La asociación Python España es una asociación sin ánimo de lucro cuyo propósito es promover el uso del lenguaje de programación Python en España, servir como punto de encuentro a aquellos interesados en su uso y darles soporte en la medida de sus posibilidades.
 
-La asociación fue creada en 2013 y desde entonces ha prestado apoyo contable y organizativo a la <a href="http://es.pycon.org" target="_new">PyConES</a>, la conferencia nacional sobre el lenguaje Python, y ayuda financiera a las comunidades locales.
+La asociación fue creada en 2013 y desde entonces ha prestado apoyo contable y organizativo a la [PyConES](https://es.pycon.org), la conferencia nacional sobre el lenguaje Python, y ayuda financiera a las comunidades locales.
 
 Si quieres apoyar nuestra labor para que podamos abordar proyectos cada vez más ambiciosos, hazte socio. Estamos deseando escuchar tus propuestas.
 
@@ -10,7 +10,7 @@ Si quieres apoyar nuestra labor para que podamos abordar proyectos cada vez más
 
 Puedes acceder a los **estatutos**, **reglamento de régimen interno**, **actas** y otra documentación en este enlace:
 
-<a href="http://documentos-asociacion.es.python.org/" target="_blank">http://documentos-asociacion.es.python.org/</a>
+http://documentos-asociacion.es.python.org/
 
 ## Datos fiscales
 

--- a/content/pages/comunidades.md
+++ b/content/pages/comunidades.md
@@ -10,7 +10,7 @@ Title: Comunidades
   integrity="sha256-/SIrNqv8h6QGKDuNoLGA4iret+kyesCkHGzVUUV0shc="
   crossorigin="anonymous"></script>
 
-<p>Aquí puedes encontrar las comunidades de Python en España. Si crees que falta alguna, <a href="https://github.com/python-spain/python-spain.github.io/edit/master/content/pages/comunidades.md">¡puedes añadirla!</a></p>
+Aquí puedes encontrar las comunidades de Python en España. Si crees que falta alguna, [¡puedes añadirla!](https://github.com/python-spain/python-spain.github.io/edit/master/content/pages/comunidades.md)
 
 <div id="map" style="height: 600px"></div>
 

--- a/content/pages/patrocinadores.md
+++ b/content/pages/patrocinadores.md
@@ -1,12 +1,12 @@
 Title: Patrocinadores
 
 
-[![Logo APSL]({filename}/images/apsl.jpg)](http://apsl.net){:target="_blank"}
-[![Logo Kaleidos]({filename}/images/kaleidos.svg)](http://kaleidos.net){:target="_blank"}
+[![Logo APSL]({filename}/images/apsl.jpg)](http://apsl.net)
+[![Logo Kaleidos]({filename}/images/kaleidos.svg)](http://kaleidos.net)
 
 # Colaboradores
 
-[![Logo Freewear]({filename}/images/freewear.png)](https://www.freewear.org/?page=list_items&org=PythonEspa%C3%B1a){:target="_blank"}
-[![Logo O'Reilly]({filename}/images/oreilly.png)](http://www.oreilly.com){:target="_blank"}
-[![Logo No Starch]({filename}/images/nostarchpress.jpg)](http://www.nostarch.com){:target="_blank"}
-[![Logo Github]({filename}/images/github.png)](http://www.github.com){:target="_blank"}
+[![Logo Freewear]({filename}/images/freewear.png)](https://www.freewear.org/?page=list_items&org=PythonEspa%C3%B1a)
+[![Logo O'Reilly]({filename}/images/oreilly.png)](http://www.oreilly.com)
+[![Logo No Starch]({filename}/images/nostarchpress.jpg)](http://www.nostarch.com)
+[![Logo Github]({filename}/images/github.png)](http://www.github.com)

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -38,3 +38,27 @@ DEFAULT_PAGINATION = 10
 THEME = 'themes/pelican-alchemy/alchemy'
 
 STATIC_PATHS = ['images']
+
+
+def open_absolute_urls_in_blank(attrs, new=False):
+    """Detect abosulte URLs (i.e. those starting with the http(s) protocol
+    and force them to be open in a new window/tab."""
+
+    _href = attrs.get((None, 'href'), 'nada')
+    if _href.startswith('http://') or _href.startswith('https://'):
+        attrs[(None, 'target')] = '_blank'
+
+    return attrs
+
+# Configure MARKDOWN extension according to:
+# https://github.com/getpelican/pelican/wiki/Tips-n-Tricks
+
+MARKDOWN = {
+    'extensions': ['mdx_linkify'],
+    'extension_configs': {
+        'markdown.extensions.extra': {},
+        'markdown.extensions.headerid': {},
+        'linkify': {'linkify_callbacks': [open_absolute_urls_in_blank]}
+    },
+    'output_format': 'html5'
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pelican==3.7.1
 ghp-import==0.5.5
 Markdown==2.6.8
+mdx_linkify==1.1


### PR DESCRIPTION
Fix #26 
Fix #25

Esta modificación permite identificar URLs automáticamente en el texto, habilita algunos extra para simplificar la edicicón de HTML con Markdown y abre las URL absolutas en nuevas ventanas/pestañas.

Se han repasado todos los artículos simplificando sus enlaces.