### PR TITLE
Añadir configuración de docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+from python:3.8
+
+COPY requirements.txt /app/
+WORKDIR /app
+RUN pip install -r requirements.txt
+
+COPY . /app
+
+CMD "./develop_server_docker.sh"

--- a/develop_server_docker.sh
+++ b/develop_server_docker.sh
@@ -1,0 +1,4 @@
+mkdir -p output
+pelican --debug --autoreload -r content -o output -s pelicanconf.py &  # build and reload contents
+cd output
+python -m pelican.server 8000  # serve contents

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  web:
+    build: .
+    ports:
+      - "8000:8000"
+    volumes:
+      - .:/app


### PR DESCRIPTION
Con esta configuración no hay que crear ningún entorno virtual, basta con ejecutar `docker-compose up` y se inicia el entorno de desarrollo, con autoreload incluído.