### PR TITLE
Actualización de la información de la nueva junta

### DIFF
--- a/content/pages/asociacion.md
+++ b/content/pages/asociacion.md
@@ -23,7 +23,7 @@ Calle La Botánica, 4, 1º
 
 ## Junta directiva
 
-Actualmente la **Junta Directiva de Python España** (2018-2020) está formada por:
+Actualmente la **Junta Directiva de Python España** (2020-2022) está formada por:
 
 |  Cargo            |  Nombre                   |  Email                           |
 | ----------------- | ------------------------- | -------------------------------- |

--- a/content/pages/asociacion.md
+++ b/content/pages/asociacion.md
@@ -27,10 +27,10 @@ Actualmente la **Junta Directiva de Python España** (2018-2020) está formada p
 
 |  Cargo            |  Nombre                   |  Email                           |
 | ----------------- | ------------------------- | -------------------------------- |
-|  Presidente       |  Israel Saeta             |  presidencia@es.python.org       |
-|  Vicepresidente   |  Xavi Torelló             |  vicepresidencia@es.python.org   |
-|  Tesorero         |  Marcos Gabarda           |  tesoreria@es.python.org         |
-|  Secretaria       |  Raúl Cumplido            |  secretaria@es.python.org        |
-|  Vocal            |  Maria Antònia Tugores    |  vocalia@es.python.org           |
-|  Vocal            |  Yamila Moreno            |  vocalia@es.python.org           |
-|  Vocal            |  David Barragán           |  vocalia@es.python.org           |
+|  Presidencia      |  Israel Saeta             |  presidencia@es.python.org       |
+|  Vicepresidencia  |  Xavi Torelló             |  vicepresidencia@es.python.org   |
+|  Tesorería        |  Marcos Gabarda           |  tesoreria@es.python.org         |
+|  Secretaría       |  Raúl Cumplido            |  secretaria@es.python.org        |
+|  Vocalía          |  Maria Antònia Tugores    |  vocalia@es.python.org           |
+|  Vocalía          |  Yamila Moreno            |  vocalia@es.python.org           |
+|  Vocalía          |  David Barragán           |  vocalia@es.python.org           |

--- a/content/pages/asociacion.md
+++ b/content/pages/asociacion.md
@@ -27,9 +27,10 @@ Actualmente la **Junta Directiva de Python España** (2018-2020) está formada p
 
 |  Cargo            |  Nombre                   |  Email                           |
 | ----------------- | ------------------------- | -------------------------------- |
-|  Presidente       |  Juan Luis Cano           |  presidencia@es.python.org       |
-|  Vicepresidente   |  Mario Corchero           |  vicepresidencia@es.python.org   |
+|  Presidente       |  Israel Saeta             |  presidencia@es.python.org       |
+|  Vicepresidente   |  Xavi Torelló             |  vicepresidencia@es.python.org   |
 |  Tesorero         |  Marcos Gabarda           |  tesoreria@es.python.org         |
-|  Secretaria       |  Mai Gimenez              |  secretaria@es.python.org        |
-|  Vocal            |  Mabel Delgado            |  vocalia@es.python.org           |
-|  Vocal            |  Pablo Galindo            |  vocalia@es.python.org           |
+|  Secretaria       |  Raúl Cumplido            |  secretaria@es.python.org        |
+|  Vocal            |  Maria Antònia Tugores    |  vocalia@es.python.org           |
+|  Vocal            |  Yamila Moreno            |  vocalia@es.python.org           |
+|  Vocal            |  David Barragán           |  vocalia@es.python.org           |


### PR DESCRIPTION
Actualiza los miembros de la nueva junta y el período de mandato.

A su vez, generaliza los cargos para evitar la asignación de género y "despersonificarlos" (p.e.`presidente` -> `presidencia`).