### PR TITLE
Eliminar correos específicos de cada cargo en Junta.

### DIFF
--- a/content/pages/asociacion.md
+++ b/content/pages/asociacion.md
@@ -23,14 +23,16 @@ Calle La Botánica, 4, 1º
 
 ## Junta directiva
 
-Actualmente la **Junta Directiva de Python España** (2020-2022) está formada por:
+Actualmente la **junta directiva de Python España** (2020-2022) está formada por:
 
-|  Cargo            |  Nombre                   |  Email                           |
-| ----------------- | ------------------------- | -------------------------------- |
-|  Presidencia      |  Israel Saeta             |  presidencia@es.python.org       |
-|  Vicepresidencia  |  Xavi Torelló             |  vicepresidencia@es.python.org   |
-|  Tesorería        |  Marcos Gabarda           |  tesoreria@es.python.org         |
-|  Secretaría       |  Raúl Cumplido            |  secretaria@es.python.org        |
-|  Vocalía          |  Maria Antònia Tugores    |  vocalia@es.python.org           |
-|  Vocalía          |  Yamila Moreno            |  vocalia@es.python.org           |
-|  Vocalía          |  David Barragán           |  vocalia@es.python.org           |
+|  Cargo            |  Nombre                   |
+| ----------------- | ------------------------- |
+|  Presidencia      |  Israel Saeta             |
+|  Vicepresidencia  |  Xavi Torelló             |
+|  Tesorería        |  Marcos Gabarda           |
+|  Secretaría       |  Raúl Cumplido            |
+|  Vocalía          |  Maria Antònia Tugores    |
+|  Vocalía          |  Yamila Moreno            |
+|  Vocalía          |  David Barragán           |
+
+Si quieres contactar con la junta escribe a [junta@es.python.org](mailto:junta@es.python.org).

--- a/themes/pelican-alchemy/alchemy/static/css/theme.css
+++ b/themes/pelican-alchemy/alchemy/static/css/theme.css
@@ -149,3 +149,12 @@ article .content blockquote{
   border-left: 4px solid lightgray;
   padding-left: 1.5rem;
 }
+
+table {
+  margin: 10px 0;
+  width: 80%;
+}
+
+th, td {
+  padding: 3px 0;
+}


### PR DESCRIPTION
Sustituir por dirección única.

También se ha aplicado un ligero estilo a la tabla para que no quedase demasiado apretada.

Antes:
![image](https://user-images.githubusercontent.com/41953/84560753-20a21d80-ad47-11ea-8985-be91b7420cf4.png)

Después:
![image](https://user-images.githubusercontent.com/41953/84560746-12540180-ad47-11ea-9f58-6c63081e1d79.png)
