### PR TITLE
Cuentas `@es.python.org`

### DIFF
--- a/content/pages/hazte-socio.md
+++ b/content/pages/hazte-socio.md
@@ -9,7 +9,7 @@ Antes de nada: **¡muchas gracias!** El proceso para asociarte es muy sencillo:
 
 1. Haz una transferencia de 30€¹ a `ES18 1491 0001 2230 0008 5378` indicando en el **asunto tu DNI/NIE/pasaporte** y en **destinatario "Asociación Python España"**.
 
-2. Mándanos un correo a [alta@es.python.org](mailto:alta@es.python.org) con **asunto "Alta nuevo socio"** adjuntando tu documento de identidad (DNI/NIE/pasaporte) escaneado, tu teléfono de contacto, el comprobante de pago y tu IBAN² para domiciliar el pago.
+2. Mándanos un correo a [alta@es.python.org](mailto:alta@es.python.org) con **asunto "Alta nuevo socio"** adjuntando tu documento de identidad (DNI/NIE/pasaporte) escaneado, tu teléfono de contacto, el comprobante de pago y tu IBAN² para domiciliar el pago. Si lo deseas, puedes obtener una cuenta de la Asociación bajo el dominio `@es.python.org`³ confirmándolo en el correo de alta.
 
 3. En unos días la Junta Directiva aprobará tu solicitud y nos pondremos en contacto contigo.
 
@@ -18,6 +18,8 @@ Antes de nada: **¡muchas gracias!** El proceso para asociarte es muy sencillo:
 ¹ Durante la segunda mitad del año (julio-diciembre inclusive) el pago será de 15€.
 
 ² Si no deseas domiciliar el pago, omite el IBAN. El próximo febrero te tocará pagar la cuota completa del año (¡te lo recordaremos!).
+
+³ La cuenta `@es.python.org` te brindará acceso a todos los servicios habilitados en nuestro Workspace de Google, incluyendo 30GB personales en Drive. Podrás solicitarlo más adelante a través del [formulario de solicitud de cuenta @es.python.org](https://docs.google.com/forms/d/19esbLPWJXTgQZKRy_tfp33UuM6typivFEqBFleqHUjk/viewform).
 
 ---
 

--- a/content/pages/hazte-socio.md
+++ b/content/pages/hazte-socio.md
@@ -19,7 +19,7 @@ Antes de nada: **¡muchas gracias!** El proceso para asociarte es muy sencillo:
 
 ² Si no deseas domiciliar el pago, omite el IBAN. El próximo febrero te tocará pagar la cuota completa del año (¡te lo recordaremos!).
 
-³ La cuenta `@es.python.org` te brindará acceso a todos los servicios habilitados en nuestro Workspace de Google, incluyendo 30GB personales en Drive. Podrás solicitarlo más adelante a través del [formulario de solicitud de cuenta @es.python.org](https://docs.google.com/forms/d/19esbLPWJXTgQZKRy_tfp33UuM6typivFEqBFleqHUjk/viewform).
+³ La cuenta `@es.python.org` te brindará acceso a todos los servicios habilitados en nuestro Workspace de Google, incluyendo 30GB personales en Drive.
 
 ---
 


### PR DESCRIPTION
Esta PR proporciona más información sobre cómo solicitar una cuenta `@es.python.org` tanto en el momento de alta (correo de alta) cómo más adelante a través del formulario de solicitud de cuenta.

Fix https://github.com/python-spain/asociacion/issues/117