### PR TITLE
Create CI to dispatch build over gh-pages branch

### DIFF
--- a/.github/workflows/build-static-site.yml
+++ b/.github/workflows/build-static-site.yml
@@ -1,0 +1,15 @@
+name: Build static site
+
+on:
+  push:
+    branches: [ "*" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build static Pelican site
+        uses: nelsonjchen/gh-pages-pelican-action@0.1.7


### PR DESCRIPTION
Now uses a wildcard for branches to be able to simplify the build verification, will be changed to master to just trigger it once a change has been merged in prod