### PR TITLE
Agregar menu para las páginas del sitio

### DIFF
--- a/themes/pelican-alchemy/alchemy/static/css/theme.css
+++ b/themes/pelican-alchemy/alchemy/static/css/theme.css
@@ -201,3 +201,29 @@ th, td {
 li p {
   margin-bottom: 0px;
 }
+
+/* Elementos para el menu de la cabecera */
+.topnav {
+  background-color: #6c6c6c;
+  overflow: hidden;
+  margin-bottom: 10px;
+}
+
+.topnav a {
+  float: left;
+  color: #f2f2f2;
+  text-align: center;
+  padding: 14px 16px;
+  text-decoration: none;
+  font-size: 14px;
+}
+
+.topnav a:hover {
+  background-color: rgba(255, 204, 18, 0.9);
+  color: black;
+}
+
+.topnav a.active {
+  background-color: #4CAF50;
+  color: white;
+}

--- a/themes/pelican-alchemy/alchemy/templates/base.html
+++ b/themes/pelican-alchemy/alchemy/templates/base.html
@@ -32,6 +32,9 @@
     <div class="container">
       {% include 'include/header.html' %}
     </div>
+    <div class="container">
+      {% include 'include/menu.html' %}
+    </div>
   </header>
 
   <div class="main">

--- a/themes/pelican-alchemy/alchemy/templates/include/header.html
+++ b/themes/pelican-alchemy/alchemy/templates/include/header.html
@@ -12,19 +12,6 @@
       <p class="text-muted">{{ SITESUBTITLE }}</p>
     {% endif %}
     {% if LINKS or (DISPLAY_PAGES_ON_MENU and pages) or ICONS %}
-      <ul class="list-inline">
-        {% for title, link in LINKS %}
-          <li class="list-inline-item"><a href="{{ link }}" target="_blank">{{ title }}</a></li>
-        {% endfor %}
-        {% if DISPLAY_PAGES_ON_MENU %}
-          {% for page in pages %}
-            {% if LINKS and loop.first %}
-              <li class="list-inline-item text-muted">|</li>
-            {% endif %}
-            <li class="list-inline-item"><a href="{{ SITEURL }}/{{ page.url }}">{{ page.title }}</a></li>
-          {% endfor %}
-        {% endif %}
-      </ul>
       {% for icon_class, link in ICONS %}
         <li class="list-inline-item" style="font-size: 20px"><a class="{{ icon_class }}" href="{{ link }}" target="_blank"></a></li>
       {% endfor %}

--- a/themes/pelican-alchemy/alchemy/templates/include/menu.html
+++ b/themes/pelican-alchemy/alchemy/templates/include/menu.html
@@ -1,0 +1,7 @@
+<div class="topnav">
+{% if DISPLAY_PAGES_ON_MENU %}
+  {% for page in pages %}
+    <a href="{{ SITEURL }}/{{ page.url }}">{{ page.title }}</a></li>
+  {% endfor %}
+{% endif %}
+</div>


### PR DESCRIPTION
Actualmente el sitio tiene las páginas como palabras
dentro de la cabecera, lo que podría ser mejorado si se presenta
como un menú de navegación.

Como utilizamos bootstrap, pensé en utilizar la versión "responsive"
pero la implementación actual no transforma el menú en un botón
hamburguesa debido a que agregar jquery (y otros dos archivos JS) para
tener la funcionalidad de un botón 'responsive' me parecía demasiado.

![2021-04-10-230256_3840x1080_scrot](https://user-images.githubusercontent.com/177982/114284564-0ad9b380-9a51-11eb-8234-566964236188.png)
